### PR TITLE
Context - Add "Generate XEH_PREP.hpp" option

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: "Publish to VS Marketplace"
 on:
   push:
     branches:
-      - main
+      - release
 
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
             {
                 "command": "lazyarmadev.copyMacroPath",
                 "title": "Copy QPATHTOF Path"
+            },
+            {
+                "command": "lazyarmadev.generatePrepFile",
+                "title": "Generate XEH_PREP.hpp"
             }
         ],
         "snippets": [
@@ -43,6 +47,11 @@
                     "command": "lazyarmadev.copyMacroPath",
                     "group": "5_cutcopypaste",
                     "when": "resourceDirname =~ /addons/"
+                },
+                {
+                    "command": "lazyarmadev.generatePrepFile",
+                    "group": "5_cutcopypaste",
+                    "when": "resourcePath =~ /functions$/"
                 }
             ]
         }

--- a/snippets/arma-config.code-snippets
+++ b/snippets/arma-config.code-snippets
@@ -7,6 +7,7 @@
             "    class ADDON {",
             "        author = AUTHOR;",
             "        authors[] = {\"${1:You}\"};",
+            "        url = ECSTRING(main,url);",
             "        name = COMPONENT_NAME;",
             "        requiredVersion = REQUIRED_VERSION;",
             "        requiredAddons[] = {\"${2:PREFIX}_main\"};",

--- a/snippets/cpp.code-snippets
+++ b/snippets/cpp.code-snippets
@@ -7,6 +7,7 @@
             "    class ADDON {",
             "        author = AUTHOR;",
             "        authors[] = {\"${1:You}\"};",
+            "        url = ECSTRING(main,url);",
             "        name = COMPONENT_NAME;",
             "        requiredVersion = REQUIRED_VERSION;",
             "        requiredAddons[] = {\"${2:PREFIX}_main\"};",

--- a/snippets/sqf.code-snippets
+++ b/snippets/sqf.code-snippets
@@ -24,7 +24,7 @@
         "body": [
             "#include \"..\\script_component.hpp\"",
             "/* ----------------------------------------------------------------------------",
-            "Function: ${1:PREFIX_COMPONENT}_fnc_${TM_FILENAME_BASE}",
+            "Function: ${1:PREFIX_COMPONENT}_${TM_FILENAME_BASE}",
             "Description:",
             "    ${2:Description}.",
             "",


### PR DESCRIPTION
## Changes
- Adds a context option to `functions` folders to generate a `XEH_PREP.hpp` file in the addon's folder.
- Only create releases on pushes to `release`
- Fix duplicate `fnc_` in CBA function header