### PR TITLE
Context - Fix using wrong name for files with multiple underscores

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -55,9 +55,10 @@ function activate(context) {
             return extension.toLowerCase() == "sqf";
         });
 
-        // Convert fnc_name.sqf -> PREP(name);
+        // Convert fnc_function_name.sqf -> PREP(function_name);
         files.forEach(function (file, index) {
-            let functionName = (file.split(".")[0]).split("_")[1];
+            let functionName = file.split(".")[0]; // Remove extension
+            functionName = (functionName.split("_").splice(1)).join("_"); // Remove fn_ / fnc_ prefix
             this[index] = `PREP(${functionName});`;
         }, files);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix using wrong names for files with multiple underscores
  - E.g. `fnc_function_name.sqf` would be PREP'd as `PREP(function);`

### Important
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None