### PR TITLE
Context - Fix not reliably copying macro path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,8 +41,8 @@ async function copyPath(macroPath: string, useExternal: boolean = false) {
     }
 
     logMessage(ELogLevel.INFO, `Copied path to clipboard: ${macroPath}`);
-    await vscode.window.showInformationMessage(`Copied ${macroPath} path to clipboard`);
     await vscode.env.clipboard.writeText(macroPath);
+    await vscode.window.showInformationMessage(`Copied ${macroPath} path to clipboard`);
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,12 @@ import { extname, join, parse } from "path";
 
 let channel: vscode.OutputChannel = vscode.window.createOutputChannel("LazyArmaDev");
 
+/*
+ Important notes:
+ A showXMessage function should always be the last line.
+ These return an awaitable state that resolves when the window of that message disapears, so any lines after may not run.
+ */
+
 /**
  * Logs a message to the debug console
  * @param {String} level Log level, e.g. TRACE, INFO, WARN, ERROR
@@ -199,8 +205,8 @@ function activate(context: vscode.ExtensionContext) {
 </Project>`;
             try {
                 await fs.writeFile(stringtableDir, content);
-                vscode.window.showInformationMessage(`Automatically generated missing stringtable.xml file`);
                 await addStringTableKey(stringtableDir, stringKey);
+                vscode.window.showInformationMessage(`Automatically generated missing stringtable.xml file`);
             } catch (err) {
                 await vscode.window.showErrorMessage(`Failed to create missing stringtable file at ${stringtableDir}`);
             }


### PR DESCRIPTION
Closes #28 

**When merged this pull request will:**
- Fix not copying the macro path reliably
- Fix a potential issue with generating stringtable keys
  - Same setup as macro paths, but I haven't noticed any issues

### Important
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None