### PR TITLE
General - Add support for optional addons, add new copy path options

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
                 "title": "Copy Resolved Path"
             },
             {
+                "command": "lazyarmadev.copyResolvedP3DPath",
+                "title": "Copy Resolved Path (P3D)"
+            },
+            {
                 "command": "lazyarmadev.generatePrepFile",
                 "title": "Generate XEH_PREP.hpp"
             },
@@ -83,6 +87,10 @@
                 {
                     "command": "lazyarmadev.copyResolvedPath",
                     "group": "lazyarmadev@3"
+                },
+                {
+                    "command": "lazyarmadev.copyResolvedP3DPath",
+                    "group": "lazyarmadev@4"
                 }
             ],
             "explorer/context": [

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
             "editor/context": [
                 {
                     "command": "lazyarmadev.generateStringtableKey",
-                    "when": "resourceDirname =~ /addons/i && LazyArmaDev.selectedStringtableMacro"
+                    "when": "resourceDirname =~ /optionals/i || resourceDirname =~ /addons/i && LazyArmaDev.selectedStringtableMacro"
                 }
             ]
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,11 @@ async function copyPath(path: string, pathType: PathType = PathType.MACRO) {
         }
         case PathType.RESOLVED: {
             const projectPrefix = await getProjectPrefix(path);
+            path = `"\\${projectPrefix.mainPrefix}\\${projectPrefix.prefix}\\addons\\${projectPrefix.component}\\${join(...pathArray)}"`;
+            break;
+        }
+        case PathType.RESOLVED_P3D: {
+            const projectPrefix = await getProjectPrefix(path);
             path = `${projectPrefix.mainPrefix}\\${projectPrefix.prefix}\\addons\\${projectPrefix.component}\\${join(...pathArray)}`;
             break;
         }
@@ -182,6 +187,14 @@ function activate(context: vscode.ExtensionContext) {
         await copyPath(join(...path), PathType.RESOLVED);
     });
     context.subscriptions.push(copyResolvedPath);
+
+    const copyResolvedP3DPath = vscode.commands.registerCommand("lazyarmadev.copyResolvedP3DPath", async (editor) => {
+        if (!editor) { return; }
+        let path = editor.path.split("/");
+        path.shift();
+        await copyPath(join(...path), PathType.RESOLVED_P3D);
+    });
+    context.subscriptions.push(copyResolvedP3DPath);
 
     const generatePrepFile = vscode.commands.registerCommand("lazyarmadev.generatePrepFile", async (editor) => {
         if (!editor) { return; }

--- a/src/path-type.ts
+++ b/src/path-type.ts
@@ -1,5 +1,6 @@
 export enum PathType {
     MACRO = "QPATHTOF",
     MACRO_EXTERNAL = "QPATHTOEF",
-    RESOLVED = "Resolved"
+    RESOLVED = "Resolved",
+    RESOLVED_P3D = "Resolved (P3D)"
 }


### PR DESCRIPTION
Closes #31 #36 

**When merged this pull request will:**
- Fix actions not working / appearing in optional addons
- Respect `insertFinalNewline` setting
- Change "resolved" path to include quotes and leading slash
- Add "p3d" path option, same as old resolved path option

### Important
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None